### PR TITLE
Improve responsivity

### DIFF
--- a/assets/stylesheets/application.css
+++ b/assets/stylesheets/application.css
@@ -151,7 +151,7 @@ body {
 
 .main-form {
   position: relative;
-  width: 585px;
+  max-width: 585px;
   height: 100px;
   margin: 20px auto;
 }
@@ -184,13 +184,13 @@ form.main-form p {
 .keyboard {
   position: absolute;
   top: 12px;
-  left: 525px;
+  right: 40px;
 }
 
 .microphone {
   position: absolute;
   top: 8px;
-  left: 550px;
+  right: 12px;
 }
 
 .microphone img {


### PR DESCRIPTION
`max-width` let container shrink to fit on small screens

`right` on icons. Let keyboard and microphone icons don't overflow the container when it shrinks.